### PR TITLE
Fix Shipping Bug for Checking Zip Code

### DIFF
--- a/src/components/ShippingForm/index.js
+++ b/src/components/ShippingForm/index.js
@@ -23,6 +23,7 @@ function ShippingForm({ confirmShipping }) {
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    const zipRegex = new RegExp('^[1-9][0-9]{5}$');
 
     if (!name) {
       return toast.error('Enter your Name');
@@ -45,7 +46,9 @@ function ShippingForm({ confirmShipping }) {
     if (!country) {
       return toast.error('Enter your Country');
     }
-
+    if (!zipRegex.test(postal_code)) {
+      return toast.error('Enter Valid Zip Code');
+    }
     return confirmShipping();
   };
 
@@ -108,7 +111,7 @@ function ShippingForm({ confirmShipping }) {
           {/* address postal code */}
           <div className='form-control'>
             <input
-              type='text'
+              type='number'
               name='postal_code'
               className='input'
               placeholder='Zip Code'

--- a/src/components/ShippingForm/index.js
+++ b/src/components/ShippingForm/index.js
@@ -37,6 +37,9 @@ function ShippingForm({ confirmShipping }) {
     if (!postal_code) {
       return toast.error('Enter your Zip Code');
     }
+    if (!zipRegex.test(postal_code)) {
+      return toast.error('Enter Valid Zip Code');
+    }
     if (!city) {
       return toast.error('Enter your City');
     }
@@ -45,9 +48,6 @@ function ShippingForm({ confirmShipping }) {
     }
     if (!country) {
       return toast.error('Enter your Country');
-    }
-    if (!zipRegex.test(postal_code)) {
-      return toast.error('Enter Valid Zip Code');
     }
     return confirmShipping();
   };


### PR DESCRIPTION
Reference No: #30

Implement RegEx for Zip Code Validation in Shipping Page  Form. Only Numeric 6 Digits will be allowed in Zip Code.

File Change

![image](https://user-images.githubusercontent.com/59647563/156890120-be54c52f-9823-458c-9929-35bb4de69691.png)

Note -

While I was working on Zipcode, I notice a bug that whenever a user changes phone number in shipping form, a warning error occurs about uncontrolled and controlled values for the phone number section. I am a little bit unaware of this error. I also followed the same steps at the official deployed site, but the error warning did not pop up over there.

Error -

![image](https://user-images.githubusercontent.com/59647563/156890195-0ad26c19-a7ad-4a45-8283-6efc4042527e.png)
